### PR TITLE
Potential fix for code scanning alert no. 1: Missing origin verification in `postMessage` handler

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,4 +1,5 @@
 const CACHE_NAME = 'multiplication-practice-v3';
+const TRUSTED_ORIGIN = 'https://www.example.com'; // <-- Set this to your app's origin
 const urlsToCache = [
   './',
   './index.html',
@@ -60,7 +61,18 @@ self.addEventListener('activate', event => {
 
 // Handle messages from the main thread
 self.addEventListener('message', event => {
-  if (event.data && event.data.type === 'SKIP_WAITING') {
-    self.skipWaiting();
+  // Origin verification
+  if (!event.source || !event.source.id) {
+    // Unable to verify sender, do nothing
+    return;
   }
+  self.clients.get(event.source.id).then(client => {
+    if (!client || !client.url || !client.url.startsWith(TRUSTED_ORIGIN)) {
+      // Not from a trusted origin
+      return;
+    }
+    if (event.data && event.data.type === 'SKIP_WAITING') {
+      self.skipWaiting();
+    }
+  });
 });


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/Multiplier/security/code-scanning/1](https://github.com/commjoen/Multiplier/security/code-scanning/1)

The fix is to verify the sender of the message before taking action. In the service worker, `event.origin` is not available, but the `event.source` property can be used to obtain a reference to the client (the page that sent the message). We can use the `clients.get()` method to retrieve the `Client` object and check its `url` against a list of trusted origins or URLs (for instance, make sure only requests from your app's host/domain are actionable). As a minimal fix, we can check that the origin of the client's URL starts with the expected trusted origin (e.g., `'https://www.example.com'` or whatever the app origin is), and only process the message if it matches.

This means for the message event handler (lines 62–66), we need to:
- Use `event.source.id` to retrieve the `Client` object,
- Use that `Client` object's `url` to check the origin,
- Only process the message if the client is known/trusted.

We could define a constant (e.g., `TRUSTED_ORIGIN`) at the top of the file or alongside other constants.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
