### PR TITLE
Potential fix for code scanning alert no. 2: Missing origin verification in `postMessage` handler

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -67,7 +67,19 @@ self.addEventListener('message', event => {
     return;
   }
   self.clients.get(event.source.id).then(client => {
-    if (!client || !client.url || !client.url.startsWith(TRUSTED_ORIGIN)) {
+    if (!client || !client.url) {
+      // Not from a trusted origin
+      return;
+    }
+    // Compare the origins strictly using the URL API
+    let clientOrigin;
+    try {
+      clientOrigin = new URL(client.url).origin;
+    } catch (e) {
+      // Malformed URL, do not proceed
+      return;
+    }
+    if (clientOrigin !== TRUSTED_ORIGIN) {
       // Not from a trusted origin
       return;
     }


### PR DESCRIPTION
Potential fix for [https://github.com/commjoen/Multiplier/security/code-scanning/2](https://github.com/commjoen/Multiplier/security/code-scanning/2)

To fix the missing or insufficient origin verification in the `postMessage` handler, we should strictly compare the origin of the sending client against the trusted origin. Since Service Workers do not have access to `event.origin`, we need to parse the client URL and compare its origin (scheme + host + port) with `TRUSTED_ORIGIN`. This should be done using the URL API for robust comparison, rather than using `.startsWith()` on the URL. The code to retrieve the client's origin from `client.url` and strictly compare it should be added in the message handler (lines 69–73). No new imports are needed, as the built-in `URL` class is available in service worker scripts.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
